### PR TITLE
Fixed error in NISTX silicon data file

### DIFF
--- a/Data/NISTX/Elements/14-Silicon.nistx
+++ b/Data/NISTX/Elements/14-Silicon.nistx
@@ -19,7 +19,6 @@ Silicon
 # Attenuation data
 # Each row includes a photon energy, a mass attenuation coefficient, and a mass
 # energy absorption coefficient
-
 1.00000E-03  1.570E+03  1.567E+03 
 1.50000E-03  5.355E+02  5.331E+02 
 1.83890E-03  3.092E+02  3.070E+02 


### PR DESCRIPTION
There was an extra newline in the Silicon data file. This was deleted so that the format matches the others